### PR TITLE
Re-point scripts to re-created board

### DIFF
--- a/js/global.js
+++ b/js/global.js
@@ -47,13 +47,13 @@ var WEBS = {
 			bodyClass: 'mustang'
 		},
 		'Watchmen': {
-			id: 60,
+			id: 193,
 			nav: 'Watchmen',
 			navCat: 'Identity',
 			bodyClass: 'Watchmen'
 		},
 		'Watchmen (Archimedes)': {
-			id: 167,
+			id: 194,
 			//nav: 'Watchmen',
 			//navCat: 'Identity',
 			bodyClass: 'Watchmen'


### PR DESCRIPTION
In trying to update our board's filter, somehow I deleted our old boards and cannot seem to restore them. The ids are for replacement boards.
